### PR TITLE
Implement mvv-lva ordering in quiescence

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -76,6 +76,9 @@ pub fn quiescence<T: BitInt>(
             captures.push(act);
         }
     }
+    captures.sort_by(|&a, &b| {
+        mvv_lva(board, b).cmp(&mvv_lva(board, a))
+    });
 
     for act in captures {
         let history = board.play(act);


### PR DESCRIPTION
```
--------------------------------------------------
Results of Artifact vs ArtiNoQSOrdering (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 40.51 +/- 16.73, nElo: 70.37 +/- 28.78
LOS: 100.00 %, DrawRatio: 50.36 %, PairsRatio: 2.23
Games: 560, Wins: 134, Losses: 69, Draws: 357, Points: 312.5 (55.80 %)
Ptnml(0-2): [4, 39, 141, 80, 16], WL/DD Ratio: 0.18
LLR: 2.90 (100.2%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```