### PR TITLE
Add TT Move Ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ List of current features:
     - Move Ordering:
         - [MVV-LVA](https://www.chessprogramming.org/MVV-LVA)
         - [History Heuristic](https://www.chessprogramming.org/History_Heuristic)
+        - [Transposition Table](https://www.chessprogramming.org/Transposition_Table)
 - Evaluation:
     - [Stalemate](https://www.chessprogramming.org/Stalemate)
     - [Checkmate](https://www.chessprogramming.org/Checkmate), prioritizes faster checkmates

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{io, thread, time::Duration};
+use std::{io, process, thread, time::Duration};
 
 use chessing::{chess::Chess, game::{GameTemplate, Team}, uci::{parse::{GoOption, UciCommand, UciPosition}, respond::Info, Uci}};
 use search::{iterative_deepening, search, SearchInfo};
@@ -47,6 +47,9 @@ fn main() {
                                 max_time = max_time.map(|el| el + (inc / 30)).or(Some(inc / 30));
                             }
                         }
+                        GoOption::MoveTime(time) => {
+                            max_time = Some(time / 10);
+                        }
                         _ => {}
                     }
                 }
@@ -78,7 +81,7 @@ fn main() {
                 }
             }
             UciCommand::Quit() => {
-                // TODO
+                process::exit(0x100);
             }
             UciCommand::Stop() => {
                 // TODO


### PR DESCRIPTION
```
--------------------------------------------------
Results of Artifact vs ArtiNoTTOrdering (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 33.59 +/- 15.35, nElo: 58.22 +/- 26.43
LOS: 100.00 %, DrawRatio: 48.19 %, PairsRatio: 1.77
Games: 664, Wins: 148, Losses: 84, Draws: 432, Points: 364.0 (54.82 %)
Ptnml(0-2): [2, 60, 160, 92, 18], WL/DD Ratio: 0.14
LLR: 2.93 (101.3%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```
Also adds in a bit of the UCI protocol