### PR TITLE
TT Cutoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ List of current features:
     - [Alpha-Beta Pruning](https://www.chessprogramming.org/Alpha-Beta)
     - [Quiescence Search](https://www.chessprogramming.org/Quiescence_Search) (capture only)
     - [Iterative Deepening](https://www.chessprogramming.org/Iterative_Deepening)
+    - [Transposition Table](https://www.chessprogramming.org/Transposition_Table) cutoffs and ordering
     - Move Ordering:
         - [MVV-LVA](https://www.chessprogramming.org/MVV-LVA)
         - [History Heuristic](https://www.chessprogramming.org/History_Heuristic)
-        - [Transposition Table](https://www.chessprogramming.org/Transposition_Table)
 - Evaluation:
     - [Stalemate](https://www.chessprogramming.org/Stalemate)
     - [Checkmate](https://www.chessprogramming.org/Checkmate), prioritizes faster checkmates


### PR DESCRIPTION
```
--------------------------------------------------
Results of Artifact vs ArtiNoTTCutoffs (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 32.30 +/- 14.76, nElo: 56.21 +/- 25.52
LOS: 100.00 %, DrawRatio: 50.28 %, PairsRatio: 1.90
Games: 712, Wins: 162, Losses: 96, Draws: 454, Points: 389.0 (54.63 %)
Ptnml(0-2): [6, 55, 179, 99, 17], WL/DD Ratio: 0.19
LLR: 2.93 (101.3%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```