### PR TITLE
Minor optimizations & Repetition Detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,41 +22,41 @@ fn main() {
                 uci.uciok();
             }
             UciCommand::Go { options } => {
-                let mut max_time = None::<u64>;
+                let mut soft_time = 0;
                 let team = board.state.moving_team;
                 
                 for option in options {
                     match option {
                         GoOption::BTime(time) => {
                             if team == Team::Black {
-                                max_time = max_time.map(|el| el + (time / 300)).or(Some(time / 300));
+                                soft_time += time / 300;
                             }
                         }
                         GoOption::BInc(inc) => {
-                            if team == Team::Black {
-                                max_time = max_time.map(|el| el + (inc / 30)).or(Some(inc / 30));
-                            }
+                            soft_time += inc / 30;
                         }
                         GoOption::WTime(time) => {
                             if team == Team::White {
-                                max_time = max_time.map(|el| el + (time / 300)).or(Some(time / 300));
+                                soft_time += time / 300;
                             }
                         }
                         GoOption::WInc(inc) => {
                             if team == Team::White {
-                                max_time = max_time.map(|el| el + (inc / 30)).or(Some(inc / 30));
+                                soft_time += inc / 30;
                             }
                         }
                         GoOption::MoveTime(time) => {
-                            max_time = Some(time / 10);
+                            soft_time += time / 10;
                         }
                         _ => {}
                     }
                 }
 
-                let max_time = max_time.unwrap_or(300);
+                if soft_time == 0 {
+                    soft_time = 300;
+                }
 
-                let info = iterative_deepening(&uci, &mut board, max_time);
+                let info = iterative_deepening(&uci, &mut board, soft_time);
 
                 let action = info.best_move.expect("There's a best move, right?");
                 let action_display = board.display_uci_action(action);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ fn main() {
     let chess = Chess::create::<u64>();
     let mut board = chess.default();
 
+    let mut hashes: Vec<u64> = vec![];
+    let zobrist = board.game.processor.gen_zobrist(&mut board, 64);
+
     for line in stdin.lines() {
         let line = line.expect("Line is set");
 
@@ -56,7 +59,8 @@ fn main() {
                     soft_time = 300;
                 }
 
-                let info = iterative_deepening(&uci, &mut board, soft_time);
+                let zobrist = board.game.processor.gen_zobrist(&mut board, 64);
+                let info = iterative_deepening(&uci, &mut board, soft_time, zobrist, hashes.clone());
 
                 let action = info.best_move.expect("There's a best move, right?");
                 let action_display = board.display_uci_action(action);
@@ -76,7 +80,11 @@ fn main() {
                     }
                 }
 
+                hashes = vec![];
+
                 for act in moves {
+                    hashes.push(chess.processor.hash(&mut board, &zobrist));
+
                     board.play_action(&act);
                 }
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -252,9 +252,9 @@ pub fn iterative_deepening<T: BitInt>(uci: &Uci, board: &mut Board<T>, soft_time
         score: 0
     };
 
+    let start = current_time_millis();
+    
     for depth in 1..100 {
-        let start = current_time_millis();
-        
         info.root_depth = depth;
         let score = search(board, &mut info, depth, 0, MIN, MAX);
         info.score = score;

--- a/src/search.rs
+++ b/src/search.rs
@@ -222,7 +222,7 @@ pub fn search<T: BitInt>(
             break;
         }
     }
-
+    
     if depth == info.root_depth {
         info.best_move = best_move;
     }
@@ -238,14 +238,14 @@ pub fn search<T: BitInt>(
     best
 }
 
-pub fn iterative_deepening<T: BitInt>(uci: &Uci, board: &mut Board<T>, max_time: u64) -> SearchInfo {
+pub fn iterative_deepening<T: BitInt>(uci: &Uci, board: &mut Board<T>, soft_time: u64) -> SearchInfo {
     let squares = (board.game.bounds.rows * board.game.bounds.cols) as usize;
 
     let mut info = SearchInfo {
         root_depth: 0,
         best_move: None,
         history: vec![ vec![ vec![ 0; squares ]; squares ]; 2 ],
-        zobrist: board.game.processor.gen_zobrist(board),
+        zobrist: board.game.processor.gen_zobrist(board, 64),
         tt_size: 1_000_000,
         tt: vec![ None; 1_000_000 ],
         nodes: 0,
@@ -254,14 +254,14 @@ pub fn iterative_deepening<T: BitInt>(uci: &Uci, board: &mut Board<T>, max_time:
 
     for depth in 1..100 {
         let start = current_time_millis();
-
+        
         info.root_depth = depth;
         let score = search(board, &mut info, depth, 0, MIN, MAX);
         info.score = score;
 
-        let end = current_time_millis();
+        let current_time = current_time_millis();
 
-        let mut time = (end - start) as u64;
+        let mut time = (current_time - start) as u64;
         if time == 0 { time = 1; }
 
         uci.info(Info {
@@ -274,7 +274,7 @@ pub fn iterative_deepening<T: BitInt>(uci: &Uci, board: &mut Board<T>, max_time:
             ..Default::default()
         });
 
-        if time > max_time {
+        if time > soft_time {
             break;   
         }
     }


### PR DESCRIPTION
Minor optimizations for time control and move ordering (not re-computing a move's score.)

Implemented Repetition Detection (two-fold):
```
--------------------------------------------------
Results of Artifact vs ArtiNoReps (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 45.34 +/- 17.47, nElo: 78.16 +/- 29.75
LOS: 100.00 %, DrawRatio: 46.18 %, PairsRatio: 2.52
Games: 524, Wins: 150, Losses: 82, Draws: 292, Points: 296.0 (56.49 %)
Ptnml(0-2): [5, 35, 121, 89, 12], WL/DD Ratio: 0.44
LLR: 2.91 (100.7%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
Finished match
```