### PR TITLE
Implement Null Move Pruning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fastchess-ubuntu-22.04*
 engines
 config.json
 run.sh
+nonregression.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ List of current features:
     - [Transposition Table](https://www.chessprogramming.org/Transposition_Table) cutoffs and ordering
     - [Principle Variation Search](https://www.chessprogramming.org/Principal_Variation_Search)
     - [Late Move Reductions](https://www.chessprogramming.org/Late_Move_Reductions)
+    - [Reverse Futility Pruning](https://www.chessprogramming.org/Reverse_Futility_Pruning)
+    - [Null Move Pruning](https://www.chessprogramming.org/Null_Move_Pruning)
     - Move Ordering:
         - [MVV-LVA](https://www.chessprogramming.org/MVV-LVA)
         - [History Heuristic](https://www.chessprogramming.org/History_Heuristic)

--- a/src/search.rs
+++ b/src/search.rs
@@ -177,7 +177,7 @@ pub fn search<T: BitInt>(
     mut alpha: i32, 
     beta: i32, 
 ) -> i32 {
-    if depth == 0 {
+    if depth <= 0 {
         return quiescence(board, info, alpha, beta);
     }
     
@@ -244,7 +244,7 @@ pub fn search<T: BitInt>(
     let in_check = board.list_captures(king).and(king).is_set();
     board.state.restore(history);
 
-    if depth >= 5 && zugzwang_unlikely(board) && !null_last_move && !in_check && !tt_matches {
+    if depth >= 3 && zugzwang_unlikely(board) && !null_last_move && !in_check && !tt_matches {
         let reduction = 3 + (depth / 5);
         let nm_depth = depth - reduction;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -233,18 +233,13 @@ pub fn search<T: BitInt>(
     let null_last_move = match board.state.history.last() {
         Some(ActionRecord::Null()) => true,
         _ => false};
-
-    let tt_matches = match tt_hit {
-        Some(TtEntry { score, bounds: Bounds::Upper, .. }) => *score < beta,
-        _ => false
-    };
     
     let king = board.state.pieces[5].and(board.state.team_to_move());
     let history = board.play_null();
     let in_check = board.list_captures(king).and(king).is_set();
     board.state.restore(history);
 
-    if depth >= 3 && zugzwang_unlikely(board) && !null_last_move && !in_check && !tt_matches {
+    if depth >= 3 && zugzwang_unlikely(board) && !null_last_move && !in_check {
         let reduction = 3 + (depth / 5);
         let nm_depth = depth - reduction;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -245,7 +245,8 @@ pub fn search<T: BitInt>(
     board.state.restore(history);
 
     if depth >= 5 && zugzwang_unlikely(board) && !null_last_move && !in_check && !tt_matches {
-        let nm_depth = depth - 3;
+        let reduction = 3 + (depth / 5);
+        let nm_depth = depth - reduction;
 
         let history = board.play_null();
         let null_score = -search(board, info, nm_depth, ply, -beta, -beta + 1);

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, i32};
 
-use chessing::{bitboard::{BitBoard, BitInt}, game::{action::Action, zobrist::ZobristTable, Board, GameState, Team}, uci::{respond::Info, Uci}};
+use chessing::{bitboard::{BitBoard, BitInt}, game::{action::{Action, ActionRecord}, zobrist::ZobristTable, Board, GameState, Team}, uci::{respond::Info, Uci}};
 
 use crate::{eval::{eval, MATERIAL}, util::current_time_millis};
 
@@ -158,6 +158,17 @@ pub fn quiescence<T: BitInt>(
     best
 }
 
+fn zugswang_unlikely<T: BitInt>(
+    board: &mut Board<T>
+) -> bool {
+    let king = board.state.pieces[5];
+    let pawns = board.state.pieces[0];
+    let team = board.state.team_to_move();
+
+    team != team.and(king.or(pawns))
+    
+}
+
 pub fn search<T: BitInt>(
     board: &mut Board<T>, 
     info: &mut SearchInfo,
@@ -180,7 +191,8 @@ pub fn search<T: BitInt>(
 
     let mut found_best_move: Option<Action> = None;
 
-    if let Some(entry) = &info.tt[index] {
+    let tt_hit = &info.tt[index];
+    if let Some(entry) = tt_hit {
         if hash == entry.hash {
             let is_in_bounds = match entry.bounds {
                 Bounds::Exact => true,
@@ -193,6 +205,36 @@ pub fn search<T: BitInt>(
             }
 
             found_best_move = entry.best_move;
+        }
+    }
+
+    let null_last_move = match board.state.history.last() {
+        Some(ActionRecord::Null()) => true,
+        _ => false};
+
+    let tt_matches = match tt_hit {
+        Some(TtEntry { score, bounds: Bounds::Upper, .. }) => *score < beta,
+        _ => false
+    };
+    
+    let king = board.state.pieces[5].and(board.state.team_to_move());
+    let history = board.play_null();
+    let in_check = board.list_captures(king).and(king).is_set();
+    board.state.restore(history);
+
+    if depth >= 5 && zugswang_unlikely(board) && !null_last_move && !in_check && !tt_matches {
+        let nm_depth = depth - 3;
+        let history = board.play_null();
+
+        let null_score = -search(board, info, nm_depth, ply, -beta, -beta + 1);
+        board.state.restore(history);
+
+        if null_score >= beta {
+            return if null_score > MAX / 2 {
+                beta
+            } else {
+                null_score
+            }
         }
     }
 


### PR DESCRIPTION
Addition of NMP:
```
--------------------------------------------------
Results of Artifact vs ArtifactNoNMP (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 22.52 +/- 13.12, nElo: 32.56 +/- 18.90
LOS: 99.96 %, DrawRatio: 40.83 %, PairsRatio: 1.36
Games: 1298, Wins: 444, Losses: 360, Draws: 494, Points: 691.0 (53.24 %)
Ptnml(0-2): [28, 135, 265, 167, 54], WL/DD Ratio: 1.76
LLR: 2.95 (101.9%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```

Adding a depth-dependent reduction to NMP:
```
--------------------------------------------------
Results of Artifact vs ArtifactWeakNMP (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 12.88 +/- 9.39, nElo: 17.40 +/- 12.67
LOS: 99.64 %, DrawRatio: 38.37 %, PairsRatio: 1.22
Games: 2888, Wins: 971, Losses: 864, Draws: 1053, Points: 1497.5 (51.85 %)
Ptnml(0-2): [107, 294, 554, 363, 126], WL/DD Ratio: 1.80
LLR: 2.95 (102.1%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```

Make NMP conditions slightly less strict (allow for NMP at depths 3 and 4 as well):
```
--------------------------------------------------
Results of Artifact vs ArtifactWeakNMP (10+0.1, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 16.35 +/- 11.32, nElo: 20.94 +/- 14.48
LOS: 99.77 %, DrawRatio: 37.07 %, PairsRatio: 1.22
Games: 2212, Wins: 801, Losses: 697, Draws: 714, Points: 1158.0 (52.35 %)
Ptnml(0-2): [92, 222, 410, 254, 128], WL/DD Ratio: 2.45
LLR: 2.91 (100.7%) (-2.25, 2.89) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```